### PR TITLE
feat!: New h and ht function APIs

### DIFF
--- a/test/fixtures/Basic.ts
+++ b/test/fixtures/Basic.ts
@@ -1,8 +1,8 @@
-import { h, S1Node } from '../..';
+import { ht, S1Node } from '../..';
 
 type BasicComponent = S1Node & HTMLDivElement;
 
-const view = h`
+const view = ht`
   <nav id=basic>
     <a href=l1>Link 1</a>
     <a href=l2>Link 2</a>


### PR DESCRIPTION
- Tagged template literal tag function is now `ht`
- `h` function now takes a string as input
  ```ts
  function h(template: string): S1Node;
  ```

BREAKING CHANGE