### PR TITLE
feat: Refactor store implementation

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,13 @@ Originally a fork of the excellent <https://github.com/Freak613/stage0> project.
       - It's unlikely we'll use it internally due to performance overhead but developers should definately sanitize input when untrusted before passing it in... although we could create light wrapper functions
       - <https://developer.mozilla.org/en-US/docs/Web/API/Sanitizer/sanitizeFor>
       - <https://developer.mozilla.org/en-US/docs/Web/API/HTML_Sanitizer_API>
+  - New DOM utility functions
+    - `createFragment`
+    - `create`
+    - `append`
+    - `prepend`
+    - `onNodeRemove`
+  - New reactive store feature
   - Differences from the original `stage0` project:
     - `h` is now `function h(template: string): S1Node` e.g., `h('<p>#text<p>')`
     - `html` is available to use as a string template literal tag function e.g., `` html`<p>#text<p>` ``
@@ -36,7 +43,7 @@ Originally a fork of the excellent <https://github.com/Freak613/stage0> project.
   - `process.env.NODE_ENV` must be defined
   - If `process.env.NODE_ENV === 'production` you must minify `h`/`html` strings with a compatible minifier
     - Add full example with `esbuild` + `esbuild-minify-templates`
-  - Ref names should be lowercase because some browsers normalise element attribute names when rendering HTML
+  - Ref names must be lowercase because some browsers normalise element attribute names when rendering HTML
 - Add API and usage documentation
 - Add more tests
 - Add examples

--- a/src/store.ts
+++ b/src/store.ts
@@ -1,51 +1,40 @@
-type Handler<T, K extends keyof T> = (value: T[K], prev: T[K]) => unknown;
-type Handlers<T> = { [K in keyof T]?: Handler<T, K>[] };
-type StoreOn<T> = <K extends keyof T>(key: K, callback: Handler<T, K>) => void;
-type StoreOff<T> = <K extends keyof T>(key: K, callback: Handler<T, K>) => void;
-/** @returns A function that will remove the listener when called. */
-type StoreListen<T> = <K extends keyof T>(
-  key: K,
-  callback: Handler<T, K>,
-) => () => void;
+type Handler<T, K extends keyof T> = (value: T[K], prev: T[K]) => void;
 type Store<T> = T & {
-  on: StoreOn<T>;
-  off: StoreOff<T>;
-  listen: StoreListen<T>;
+  readonly on: <K extends keyof Omit<T, 'on'>>(
+    key: K,
+    callback: Handler<T, K>,
+  ) => /** off */ () => void;
 };
 
-export const store = <
-  T extends Record<string | symbol, unknown>,
-  K extends keyof T,
->(
-  initialState: T,
+/**
+ * Creates a proxied state object that triggers callback functions when its
+ * properties are set.
+ */
+export const store = <T extends Record<string | symbol, unknown>>(
+  initialState: T & { readonly on: never },
 ): Store<T> => {
-  const handlers: Handlers<T> = {};
+  const handlers: { [K in keyof T]?: Handler<T, K>[] } = {};
 
-  const proxy = new Proxy(initialState, {
-    // @ts-expect-error - FIXME: Resolve "'K' could be instantiated with a different subtype" error
-    set(target, property: K, value: T[K], receiver) {
-      if (handlers[property]) {
-        for (const listener of handlers[property]!) {
-          listener(value, target[property]);
-        }
-      }
-      return Reflect.set(target, property, value, receiver);
+  return new Proxy(
+    // proxied state object
+    {
+      ...initialState,
+      on(key, fn) {
+        (handlers[key] ??= []).push(fn);
+        return () => {
+          // eslint-disable-next-line no-bitwise
+          handlers[key]?.splice(handlers[key]!.indexOf(fn) >>> 0, 1);
+        };
+      },
     },
-  }) as Store<T>;
-
-  // TODO: Could these be added without calling the proxy setter? And while saving bytes?
-
-  proxy.on = (property, callback) => {
-    (handlers[property] ??= []).push(callback);
-  };
-  proxy.off = (property, callback) => {
-    // eslint-disable-next-line no-bitwise
-    handlers[property]?.splice(handlers[property]!.indexOf(callback) >>> 0, 1);
-  };
-  proxy.listen = (property, callback) => {
-    proxy.on(property, callback);
-    return () => proxy.off(property, callback);
-  };
-
-  return proxy;
+    // setter handler
+    {
+      set(target, property: keyof T, value: T[keyof T]) {
+        handlers[property]?.forEach((fn) => fn(value, target[property]));
+        // eslint-disable-next-line no-param-reassign
+        (target as T)[property] = value;
+        return true;
+      },
+    },
+  );
 };


### PR DESCRIPTION
- Avoid directly mutating the supplied initial state object
- Reduce output file size
- Simplify the API
- Improve types