### PR TITLE
feat: Minor tweaks, fixes, and cleanup

### DIFF
--- a/src/events.ts
+++ b/src/events.ts
@@ -1,4 +1,4 @@
-const configuredEvents: Record<string, boolean | null> = {};
+const configuredEvents: Record<string, boolean> = {};
 
 const nativeToSyntheticEvent = (event: Event) => {
   // eslint-disable-next-line prefer-template
@@ -26,5 +26,5 @@ export const setupSyntheticEvent = (type: keyof DocumentEventMap): void => {
 
 export const deleteSyntheticEvent = (type: keyof DocumentEventMap): void => {
   document.removeEventListener(type, nativeToSyntheticEvent);
-  configuredEvents[type] = null;
+  configuredEvents[type] = false;
 };

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,11 +1,18 @@
+/** @internal */
 export interface Ref {
   readonly i: number;
   readonly ref: string;
 }
 
-export type RefNodes = Record<string, Node>;
+export type Refs = Record<string, Node>;
+
+export type LowercaseKeys<T> = {
+  [K in keyof T as Lowercase<string & K>]: T[K];
+};
 
 export interface S1Node extends Node, ChildNode {
   _refs: Ref[];
-  collect<T extends RefNodes = RefNodes>(node: Node): T;
+  // Some browsers lowercase rendered HTMLElement attribute names so we
+  // lowercase the ref keys to bring awareness to this.
+  collect<T extends Refs = Refs>(node: Node): LowercaseKeys<T>;
 }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,6 +1,6 @@
 export const noop = (): void => {};
 
-// DOM
+// DOM utilities
 export const createFragment = (): DocumentFragment => new DocumentFragment();
 export const create = <K extends keyof HTMLElementTagNameMap>(
   tagName: K,
@@ -11,16 +11,16 @@ export const prepend = <T extends Node>(node: T, parent: Node): T =>
   parent.insertBefore(node, parent.firstChild);
 
 /**
- * Run callback when a specified node is removed from the DOM.
+ * Runs callback function when a specified node is removed from the DOM.
  *
- * Use sparingly to minimize performance overhead.
+ * @remarks Use sparingly to minimize performance overhead.
  */
-export const onNodeRemove = (node: Node, callback: () => void): void => {
+export const onNodeRemove = (node: Node, fn: () => void): void => {
   new MutationObserver((mutations, observer) => {
     for (const mutation of mutations) {
       for (const removedNode of mutation.removedNodes) {
         if (removedNode.contains(node)) {
-          callback();
+          fn();
           observer.disconnect();
           return;
         }

--- a/test/compile.test.ts
+++ b/test/compile.test.ts
@@ -155,16 +155,32 @@ describe('h', (test) => {
   test('does not format template when NODE_ENV=production', () => {
     const oldNodeEnv = process.env.NODE_ENV;
     process.env.NODE_ENV = 'production';
-    const view = html`<ul>
+    const view = h(`<ul>
       <li>A</li>
       <li>B</li>
       <li>C</li>
-    </ul> `;
+    </ul> `);
     const rendered = render(view);
     assert.fixture(
       rendered.container.innerHTML,
       '<ul>\n      <li>A</li>\n      <li>B</li>\n      <li>C</li>\n    </ul>',
     );
+    process.env.NODE_ENV = oldNodeEnv;
+  });
+
+  test('omits leading space to correctly render HTMLDivElement when not NODE_ENV=production', () => {
+    assert.is.not(process.env.NODE_ENV, 'production');
+    const view = h(' <div></div>');
+    const rendered = render(view);
+    assert.instance(rendered.container.firstChild, window.HTMLDivElement);
+  });
+
+  test('does not omit leading space and renders Text node when NODE_ENV=production', () => {
+    const oldNodeEnv = process.env.NODE_ENV;
+    process.env.NODE_ENV = 'production';
+    const view = h(' <div></div>');
+    const rendered = render(view);
+    assert.instance(rendered.container.firstChild, window.Text);
     process.env.NODE_ENV = oldNodeEnv;
   });
 });
@@ -182,5 +198,37 @@ describe('html', (test) => {
     `;
     const rendered = render(view);
     assert.fixture(rendered.container.innerHTML, '<ul>\n<li>A</li>\n<li>B</li>\n<li>C</li>\n</ul>');
+  });
+
+  test('does not format template when NODE_ENV=production', () => {
+    const oldNodeEnv = process.env.NODE_ENV;
+    process.env.NODE_ENV = 'production';
+    const view = html`<ul>
+      <li>A</li>
+      <li>B</li>
+      <li>C</li>
+    </ul> `;
+    const rendered = render(view);
+    assert.fixture(
+      rendered.container.innerHTML,
+      '<ul>\n      <li>A</li>\n      <li>B</li>\n      <li>C</li>\n    </ul>',
+    );
+    process.env.NODE_ENV = oldNodeEnv;
+  });
+
+  test('omits leading space to correctly render HTMLDivElement when not NODE_ENV=production', () => {
+    assert.is.not(process.env.NODE_ENV, 'production');
+    const view = html` <div></div>`;
+    const rendered = render(view);
+    assert.instance(rendered.container.firstChild, window.HTMLDivElement);
+  });
+
+  test('does not omit leading space and renders Text node when NODE_ENV=production', () => {
+    const oldNodeEnv = process.env.NODE_ENV;
+    process.env.NODE_ENV = 'production';
+    const view = html` <div></div>`;
+    const rendered = render(view);
+    assert.instance(rendered.container.firstChild, window.Text);
+    process.env.NODE_ENV = oldNodeEnv;
   });
 });

--- a/test/exports.test.ts
+++ b/test/exports.test.ts
@@ -20,6 +20,9 @@ describe('index', (test) => {
     ['append', 'Function'],
     ['prepend', 'Function'],
     ['onNodeRemove', 'Function'],
+
+    // FIXME: EXPERIMENTAL ; REMOVE!!
+    ['hf', 'Function'],
   ] as const;
 
   for (const [name, type] of PUBLIC_EXPORTS) {

--- a/test/utils.ts
+++ b/test/utils.ts
@@ -55,8 +55,8 @@ export function render(component: Node): RenderResult {
   return {
     container,
     debug(el = container) {
-      // eslint-disable-next-line no-console
-      console.log('DEBUG:\n', el.innerHTML);
+      /* prettier-ignore */ // eslint-disable-next-line
+      console.log('DEBUG:\n' + require('prettier').format(el.innerHTML, { parser: 'html' }));
     },
     unmount() {
       container.removeChild(component);
@@ -65,7 +65,11 @@ export function render(component: Node): RenderResult {
 }
 
 export function cleanup(): void {
-  if (!mountedContainers || mountedContainers.size === 0) return;
+  if (!mountedContainers || mountedContainers.size === 0) {
+    throw new Error(
+      'No mounted components exist, did you forget to call render()?',
+    );
+  }
 
   mountedContainers.forEach((container) => {
     if (container.parentNode === document.body) {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,6 +2,7 @@
   "compilerOptions": {
     "rootDir": "src",
     "outDir": "dist",
+    "declaration": true,
 
     "target": "esnext",
     "module": "esnext",
@@ -12,17 +13,14 @@
     "allowJs": true,
     "checkJs": true,
 
-    "declaration": true,
-
     "strict": true,
     "allowUnreachableCode": false,
     "exactOptionalPropertyTypes": true,
     "forceConsistentCasingInFileNames": true,
-    "noFallthroughCasesInSwitch": true,
+    "noFallthroughCasesInSwitch": false, // covered by eslint
     "noImplicitOverride": true,
-    "noUnusedLocals": true,
-    "noUnusedParameters": true,
-    "useDefineForClassFields": true,
+    "noUnusedLocals": false, // covered by eslint
+    "noUnusedParameters": false, // covered by eslint
     "verbatimModuleSyntax": true
   },
   "exclude": ["coverage", "dist", "node_modules", "test", "build.mjs"]


### PR DESCRIPTION
- Rename `RefNodes` type to `Refs`
- `collect` now expects a `Node` as the argument rather than `Element`
- `collect` now changes the ref names to lowercase (in the types) to reflect that browsers also do this
- Add experimental `S1Fragment` type and `hf` compile function (for experiments only as it may be removed at any time)
- Simplify synthetic event handler state
- Improve some tests
- Improve TypeScript config