### PR TITLE
Optimize code for performance and load times

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -4,3 +4,4 @@
 **/*.bak
 coverage/
 test/
+**/*.map

--- a/build.ts
+++ b/build.ts
@@ -17,7 +17,8 @@ const { outputs } = await Bun.build({
   define: {
     "Node.ELEMENT_NODE": "1",
   },
-  minify: true,
+  // Avoid double-minifying since we run Terser on the IIFE output
+  minify: false,
   sourcemap: "inline",
 });
 const bundle = await rollup({
@@ -39,6 +40,11 @@ await bundle.write({
             negate_iife: false,
             reduce_funcs: false,
             passes: 2,
+          },
+          mangle: {
+            safari10: true,
+            // do not mangle the global export name
+            reserved: ["stage1"],
           },
           format: {
             wrap_func_args: true,

--- a/src/browser/runtime.ts
+++ b/src/browser/runtime.ts
@@ -55,6 +55,14 @@ export const h = <T extends Node = Element>(template: string): View & T => {
     .replace(/ </g, "<");
 
   const node = compilerTemplate.content.firstChild as View & T;
+
+  // Fast path: if there are no ref markers, skip tree walking entirely
+  if (template.indexOf("@") === -1) {
+    // initialize empty metadata so downstream code can rely on it
+    (node as View)[REFS] = [] as RefMeta[];
+    return node;
+  }
+
   const metadata: RefMeta[] = (node[REFS] = []);
   let current: Node | null = (treeWalker.currentNode = node);
   let distance = 0;


### PR DESCRIPTION
Optimize bundle size and load times by refining the build process and adding a runtime fast path.

This PR improves performance by avoiding double-minification for the IIFE bundle, enabling stronger Terser mangling, excluding sourcemaps from published packages, and adding an early exit in the browser runtime to skip ref scanning when templates have no refs.

---
<a href="https://cursor.com/background-agent?bcId=bc-92a7fcde-51b8-4f70-a33e-f37e1c44467f">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-92a7fcde-51b8-4f70-a33e-f37e1c44467f">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

